### PR TITLE
Added basic operators and scaffolds. Closes #3

### DIFF
--- a/documentation/prerelease.md
+++ b/documentation/prerelease.md
@@ -1,0 +1,274 @@
+# AMSA Prerelease Snapshot
+
+## Status
+
+AMSA is currently in a prerelease stage.
+
+The project now has:
+
+- a portable algebra core based on bit-pattern blade identifiers
+- dense, grade-packed, and sparse(false) layout descriptors
+- a reference multivector array type
+- cached operator plans for binary products
+- a first reference backend split between planning and execution
+- a tested public API for the current reference semantics
+
+Current verification status:
+
+- `uv run pytest` passes
+- the test suite currently covers layout behavior, algebra presets, product planning, geometric product equivalence, outer product, inner product, and the current convenience constructors
+
+## Project Intent
+
+AMSA is meant to become a high-performance geometric algebra library for robotics, engineering, and scientific computation.
+
+The immediate direction is:
+
+- keep algebra semantics separate from storage and execution
+- treat layout-sensitive specialization as a core design choice
+- make sparse support-pattern reasoning a first-class concept
+- keep the Python/NumPy path as the reference backend
+- prepare for future optimized backends without changing algebra semantics
+
+
+## Current Architecture
+
+The codebase is currently organized around these roles:
+
+- `amsa.specs`: algebra signatures, blade naming, grade helpers, preset specs
+- `amsa.layouts`: layout descriptors for coefficient ordering and support
+- `amsa.mv`: array-backed multivectors tied to an algebra and layout
+- `amsa.plans`: immutable cached product plans for binary operators
+- `amsa.reference`: reference execution of precomputed plans
+- `amsa.ops`: public operator layer for arithmetic and involutions
+- `amsa.algebra`: user-facing constructors and convenience helpers
+
+Binary products now use a two-phase reference path:
+
+1. Build or fetch a cached `OpPlan` keyed by algebra plus the exact blade tuples of the input layouts.
+2. Execute that plan against broadcasted coefficient arrays.
+
+This is the current boundary between the pure reference backend and future optimized backend work.
+
+## Public API
+
+The top-level package currently exports:
+
+- `Algebra`
+- `AlgebraSpec`
+- `MVArray`
+- `MVLayout`
+- `add`
+- `sub`
+- `neg`
+- `geometric_product`
+- `outer_product`
+- `inner_product`
+- `reverse`
+- `involute`
+- `conjugate`
+- `project_grades`
+- `grade_of_blade`
+- `vga`
+- `vga2d`
+- `vga3d`
+- `pga2d`
+- `pga3d`
+
+## Algebra Specs
+
+`AlgebraSpec` currently provides:
+
+- signature validation
+- `dimension`
+- `blade_count`
+- `p`, `q`, `r`
+- `grades()`
+- `blade_name(blade)`
+- `blade_names()`
+- `blade_from_key(key)`
+- `blades_of_grade(grade)`
+- `grades_of_blades()`
+- `pseudoscalar_blade`
+- `blade_product(lhs, rhs)`
+- `from_pqr(...)`
+
+Preset spec constructors currently available:
+
+- `vga(dimension)`
+- `vga2d()`
+- `vga3d()`
+- `pga2d()`
+- `pga3d()`
+
+## Layouts
+
+`MVLayout` currently supports:
+
+- `MVLayout.dense(algebra)`
+- `MVLayout.grade(algebra, *grades)`
+- `MVLayout.sparse_pattern(algebra, blades, name=...)`
+
+Layout metadata currently available:
+
+- `blades`
+- `kind`
+- `name`
+- `size`
+- `grades`
+- `blade_names()`
+- `index_of(blade)`
+- `contains(blade)`
+
+## Algebra Handle
+
+`Algebra` is the main user-facing entry point and currently provides:
+
+- preset constructors:
+  - `Algebra.vga2d()`
+  - `Algebra.vga3d()`
+  - `Algebra.pga2d()`
+  - `Algebra.pga3d()`
+  - `Algebra.from_name(name)`
+- layout helpers:
+  - `dense_layout()`
+  - `grade_layout(*grades)`
+  - `even_layout()`
+  - `odd_layout()`
+  - `sparse_layout(blades, name=...)`
+- constructors:
+  - `zeros(...)`
+  - `blade(key, value=1.0)`
+  - `multivector(data, layout=None)`
+  - `scalar(value=0.0)`
+  - `kvector(grade, values)`
+  - `vector(values)`
+  - `bivector(values)`
+  - `trivector(values)`
+  - `even(values)`
+  - `odd(values)`
+  - `pseudoscalar(value=0.0)`
+- operator helpers:
+  - `gp(lhs, rhs)`
+  - `outer(lhs, rhs)`
+  - `inner(lhs, rhs)`
+  - `add(lhs, rhs)`
+  - `sub(lhs, rhs)`
+
+`Algebra.from_name(...)` currently recognizes:
+
+- `vga2d`
+- `vga3d`
+- `pga2d`
+- `2dpga`
+- `pga3d`
+- `3dpga`
+
+## Multivectors
+
+`MVArray` currently provides:
+
+- storage metadata:
+  - `algebra`
+  - `layout`
+  - `values`
+  - `batch_shape`
+  - `dtype`
+  - `grades`
+- constructors:
+  - `MVArray.zeros(...)`
+  - `MVArray.from_array(...)`
+- layout and inspection helpers:
+  - `copy()`
+  - `to_layout(layout)`
+  - `as_dense()`
+  - `component(key)`
+  - `grade(*grades)`
+- unary operations:
+  - `reverse()`
+  - `involute()`
+  - `conjugate()`
+  - unary negation via `-mv`
+- binary operations:
+  - `mv + other`
+  - `mv - other`
+  - `mv * other`
+  - `mv ^ other`
+  - `mv | other`
+  - scalar multiplication via `scalar * mv` and `mv * scalar`
+- named methods:
+  - `outer(other)`
+  - `inner(other)`
+
+## Exact Operations Available Today
+
+These are the exact algebraic operations currently implemented in the reference backend:
+
+### Binary multivector operations
+
+- addition
+- subtraction
+- geometric product
+- outer product
+- inner product
+
+### Unary multivector operations
+
+- negation
+- reverse
+- involute
+- conjugate
+
+### Scalar interactions
+
+- multivector-scalar addition
+- scalar-multivector addition
+- multivector-scalar subtraction
+- scalar-multivector subtraction
+- left scalar multiplication
+- right scalar multiplication
+
+### Projection and storage operations
+
+- projection into a target layout via `to_layout(...)`
+- dense conversion via `as_dense()`
+- grade selection via `grade(...)` and `project_grades(...)`
+- component lookup by blade id or blade name
+
+## Operator Semantics
+
+The current binary product semantics are:
+
+- geometric product:
+  - includes every nonzero blade-pair contribution produced by `blade_product`
+- outer product:
+  - includes only terms whose output grade equals the sum of the input grades
+- inner product:
+  - includes only terms whose output grade equals the absolute difference of the input grades
+
+All three products:
+
+- respect the algebra metric, including degenerate signatures
+- preserve sparse support when possible
+- return dense output only when the implied support spans the full algebra basis
+- broadcast over batch dimensions using NumPy broadcasting rules
+
+## Current Limitations
+
+The following are not implemented yet:
+
+- left contraction
+- right contraction
+- scalar product as a separate operator
+- regressive product
+- dual / undual helpers
+- inverse / division
+- sandwich operators
+- normalization helpers
+- symbolic backends
+- JAX, Triton, or PyTorch execution paths
+- backend auto-selection beyond the reference backend
+
+## Examples Folder
+
+The `/examples` directory exists but is left empty for now.

--- a/src/amsa/__init__.py
+++ b/src/amsa/__init__.py
@@ -1,8 +1,8 @@
 from amsa.algebra import Algebra
 from amsa.layouts import MVLayout
 from amsa.mv import MVArray
-from amsa.ops import add, conjugate, geometric_product, involute, neg, reverse, sub
-from amsa.specs import AlgebraSpec, grade_of_blade, pga2d, pga3d, vga
+from amsa.ops import add, conjugate, geometric_product, inner_product, involute, neg, outer_product, project_grades, reverse, sub
+from amsa.specs import AlgebraSpec, grade_of_blade, pga2d, pga3d, vga, vga2d, vga3d
 
 __all__ = [
     "Algebra",
@@ -13,11 +13,16 @@ __all__ = [
     "conjugate",
     "geometric_product",
     "grade_of_blade",
+    "inner_product",
     "involute",
     "neg",
+    "outer_product",
     "pga2d",
     "pga3d",
+    "project_grades",
     "reverse",
     "sub",
     "vga",
+    "vga2d",
+    "vga3d",
 ]

--- a/src/amsa/algebra.py
+++ b/src/amsa/algebra.py
@@ -8,7 +8,11 @@ import numpy as np
 
 from amsa.layouts import MVLayout
 from amsa.mv import MVArray
-from amsa.specs import AlgebraSpec
+from amsa.ops import add as add_op
+from amsa.ops import inner_product as inner_op
+from amsa.ops import outer_product as outer_op
+from amsa.ops import sub as sub_op
+from amsa.specs import AlgebraSpec, pga2d as pga2d_spec, pga3d as pga3d_spec, vga2d as vga2d_spec, vga3d as vga3d_spec
 
 
 @dataclass(frozen=True, slots=True)
@@ -16,6 +20,39 @@ class Algebra:
     """User-facing algebra handle for the initial scaffold."""
 
     spec: AlgebraSpec
+
+    @classmethod
+    def vga2d(cls) -> Algebra:
+        return cls(vga2d_spec())
+
+    @classmethod
+    def vga3d(cls) -> Algebra:
+        return cls(vga3d_spec())
+
+    @classmethod
+    def pga2d(cls) -> Algebra:
+        return cls(pga2d_spec())
+
+    @classmethod
+    def pga3d(cls) -> Algebra:
+        return cls(pga3d_spec())
+
+    @classmethod
+    def from_name(cls, name: str) -> Algebra:
+        normalized = "".join(char for char in name.casefold() if char.isalnum())
+        presets = {
+            "vga2d": vga2d_spec,
+            "vga3d": vga3d_spec,
+            "pga2d": pga2d_spec,
+            "2dpga": pga2d_spec,
+            "pga3d": pga3d_spec,
+            "3dpga": pga3d_spec,
+        }
+        try:
+            return cls(presets[normalized]())
+        except KeyError as exc:
+            supported = ", ".join(sorted(presets))
+            raise ValueError(f"Unknown algebra preset {name!r}. Supported presets: {supported}.") from exc
 
     @property
     def dimension(self) -> int:
@@ -30,6 +67,12 @@ class Algebra:
 
     def grade_layout(self, *grades: int) -> MVLayout:
         return MVLayout.grade(self.spec, *grades)
+
+    def even_layout(self) -> MVLayout:
+        return self.grade_layout(*range(0, self.dimension + 1, 2))
+
+    def odd_layout(self) -> MVLayout:
+        return self.grade_layout(*range(1, self.dimension + 1, 2))
 
     def sparse_layout(self, blades: tuple[int, ...], *, name: str = "sparse") -> MVLayout:
         return MVLayout.sparse_pattern(self.spec, blades, name=name)
@@ -97,14 +140,40 @@ class Algebra:
     def scalar(self, value: Any = 0.0) -> MVArray:
         return self.multivector([value], layout=self.grade_layout(0))
 
+    def kvector(self, grade: int, values: Any) -> MVArray:
+        return self.multivector(values, layout=self.grade_layout(grade))
+
     def vector(self, values: Any) -> MVArray:
-        return self.multivector(values, layout=self.grade_layout(1))
+        return self.kvector(1, values)
 
     def bivector(self, values: Any) -> MVArray:
-        return self.multivector(values, layout=self.grade_layout(2))
+        return self.kvector(2, values)
+
+    def trivector(self, values: Any) -> MVArray:
+        return self.kvector(3, values)
+
+    def even(self, values: Any) -> MVArray:
+        return self.multivector(values, layout=self.even_layout())
+
+    def odd(self, values: Any) -> MVArray:
+        return self.multivector(values, layout=self.odd_layout())
 
     def pseudoscalar(self, value: Any = 0.0) -> MVArray:
         return self.multivector([value], layout=self.grade_layout(self.dimension))
 
     def gp(self, lhs: MVArray, rhs: MVArray) -> MVArray:
         return lhs * rhs
+
+    def outer(self, lhs: MVArray, rhs: MVArray) -> MVArray:
+        return outer_op(lhs, rhs)
+
+    def inner(self, lhs: MVArray, rhs: MVArray) -> MVArray:
+        return inner_op(lhs, rhs)
+
+    def add(self, lhs: MVArray | Any, rhs: MVArray | Any) -> MVArray:
+        left = self.scalar(lhs) if np.isscalar(lhs) else self.multivector(lhs)
+        return add_op(left, rhs)
+
+    def sub(self, lhs: MVArray | Any, rhs: MVArray | Any) -> MVArray:
+        left = self.scalar(lhs) if np.isscalar(lhs) else self.multivector(lhs)
+        return sub_op(left, rhs)

--- a/src/amsa/mv.py
+++ b/src/amsa/mv.py
@@ -43,6 +43,10 @@ class MVArray:
     def dtype(self) -> np.dtype[Any]:
         return self.values.dtype
 
+    @property
+    def grades(self) -> tuple[int, ...]:
+        return self.layout.grades
+
     @classmethod
     def zeros(
         cls,
@@ -94,13 +98,9 @@ class MVArray:
         return self.values.dtype.type(0)
 
     def grade(self, *grades: int) -> MVArray:
-        if len(grades) == 1 and isinstance(grades[0], tuple):
-            grades = grades[0]
-        selected = tuple(
-            blade for blade in self.layout.blades if blade.bit_count() in set(grades)
-        )
-        layout = MVLayout.sparse_pattern(self.algebra, selected, name="grade-select")
-        return self.to_layout(layout)
+        from amsa.ops import project_grades
+
+        return project_grades(self, *grades)
 
     def reverse(self) -> MVArray:
         from amsa.ops import reverse
@@ -117,24 +117,57 @@ class MVArray:
 
         return conjugate(self)
 
+    def outer(self, other: MVArray) -> MVArray:
+        from amsa.ops import outer_product
+
+        return outer_product(self, other)
+
+    def inner(self, other: MVArray) -> MVArray:
+        from amsa.ops import inner_product
+
+        return inner_product(self, other)
+
     def __neg__(self) -> MVArray:
         from amsa.ops import neg
 
         return neg(self)
 
     def __add__(self, other: MVArray) -> MVArray:
-        if not isinstance(other, MVArray):
-            return NotImplemented
         from amsa.ops import add
 
-        return add(self, other)
+        try:
+            return add(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __radd__(self, other: Number) -> MVArray:
+        from amsa.ops import add
+
+        try:
+            return add(self, other)
+        except TypeError:
+            return NotImplemented
 
     def __sub__(self, other: MVArray) -> MVArray:
-        if not isinstance(other, MVArray):
-            return NotImplemented
         from amsa.ops import sub
 
-        return sub(self, other)
+        try:
+            return sub(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __rsub__(self, other: Number) -> MVArray:
+        from amsa.ops import sub
+
+        if isinstance(other, Number):
+            scalar_layout = MVLayout.grade(self.algebra, 0)
+            scalar = MVArray(
+                algebra=self.algebra,
+                layout=scalar_layout,
+                values=np.asarray([other], dtype=np.result_type(self.dtype, other)),
+            )
+            return sub(scalar, self)
+        return NotImplemented
 
     def __mul__(self, other: MVArray | Number) -> MVArray:
         if isinstance(other, MVArray):
@@ -149,3 +182,19 @@ class MVArray:
         if isinstance(other, Number):
             return MVArray(algebra=self.algebra, layout=self.layout, values=other * self.values)
         return NotImplemented
+
+    def __xor__(self, other: MVArray) -> MVArray:
+        from amsa.ops import outer_product
+
+        try:
+            return outer_product(self, other)
+        except TypeError:
+            return NotImplemented
+
+    def __or__(self, other: MVArray) -> MVArray:
+        from amsa.ops import inner_product
+
+        try:
+            return inner_product(self, other)
+        except TypeError:
+            return NotImplemented

--- a/src/amsa/ops.py
+++ b/src/amsa/ops.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from numbers import Number
 from typing import Any
 
 import numpy as np
 
 from amsa.layouts import MVLayout
 from amsa.mv import MVArray
+from amsa.plans import OpKind, plan_binary_product
+from amsa.reference import execute_binary_plan
+from amsa.specs import grade_of_blade
 
 
 def ensure_compatible(lhs: MVArray, rhs: MVArray) -> None:
@@ -14,32 +18,43 @@ def ensure_compatible(lhs: MVArray, rhs: MVArray) -> None:
         raise ValueError("Multivectors belong to different algebras.")
 
 
+def _coerce_operand(reference: MVArray, operand: MVArray | Number) -> MVArray:
+    if isinstance(operand, MVArray):
+        ensure_compatible(reference, operand)
+        return operand
+    if isinstance(operand, Number):
+        scalar_layout = MVLayout.grade(reference.algebra, 0)
+        values = np.asarray([operand], dtype=np.result_type(reference.dtype, operand))
+        return MVArray(algebra=reference.algebra, layout=scalar_layout, values=values)
+    raise TypeError(f"Unsupported operand type: {type(operand)!r}")
+
+
 def neg(mv: MVArray) -> MVArray:
     return MVArray(algebra=mv.algebra, layout=mv.layout, values=-mv.values)
 
 
-def _union_layout(lhs: MVArray, rhs: MVArray) -> MVLayout:
-    ensure_compatible(lhs, rhs)
-    if lhs.layout == rhs.layout:
-        return lhs.layout
+def _union_layout(lhs: MVArray, rhs: MVArray | Number) -> tuple[MVArray, MVLayout]:
+    rhs_mv = _coerce_operand(lhs, rhs)
+    if lhs.layout == rhs_mv.layout:
+        return rhs_mv, lhs.layout
 
-    blades = tuple(sorted(set(lhs.layout.blades) | set(rhs.layout.blades)))
+    blades = tuple(sorted(set(lhs.layout.blades) | set(rhs_mv.layout.blades)))
     if len(blades) == lhs.algebra.blade_count:
-        return MVLayout.dense(lhs.algebra)
-    return MVLayout.sparse_pattern(lhs.algebra, blades, name="union")
+        return rhs_mv, MVLayout.dense(lhs.algebra)
+    return rhs_mv, MVLayout.sparse_pattern(lhs.algebra, blades, name="union")
 
 
-def add(lhs: MVArray, rhs: MVArray) -> MVArray:
-    layout = _union_layout(lhs, rhs)
+def add(lhs: MVArray, rhs: MVArray | Number) -> MVArray:
+    rhs_mv, layout = _union_layout(lhs, rhs)
     lhs_projected = lhs.to_layout(layout)
-    rhs_projected = rhs.to_layout(layout)
+    rhs_projected = rhs_mv.to_layout(layout)
     return MVArray(algebra=lhs.algebra, layout=layout, values=lhs_projected.values + rhs_projected.values)
 
 
-def sub(lhs: MVArray, rhs: MVArray) -> MVArray:
-    layout = _union_layout(lhs, rhs)
+def sub(lhs: MVArray, rhs: MVArray | Number) -> MVArray:
+    rhs_mv, layout = _union_layout(lhs, rhs)
     lhs_projected = lhs.to_layout(layout)
-    rhs_projected = rhs.to_layout(layout)
+    rhs_projected = rhs_mv.to_layout(layout)
     return MVArray(algebra=lhs.algebra, layout=layout, values=lhs_projected.values - rhs_projected.values)
 
 
@@ -60,37 +75,38 @@ def conjugate(mv: MVArray) -> MVArray:
     return reverse(involute(mv))
 
 
-def geometric_product(lhs: MVArray, rhs: MVArray) -> MVArray:
+def _execute_binary_product(lhs: MVArray, rhs: MVArray, kind: OpKind) -> MVArray:
     ensure_compatible(lhs, rhs)
-    batch_shape = np.broadcast_shapes(lhs.batch_shape, rhs.batch_shape)
-    lhs_values = np.broadcast_to(lhs.values, batch_shape + (lhs.layout.size,))
-    rhs_values = np.broadcast_to(rhs.values, batch_shape + (rhs.layout.size,))
+    plan = plan_binary_product(lhs.layout, rhs.layout, kind)
+    return execute_binary_plan(lhs, rhs, plan)
 
-    support: set[int] = set()
-    accumulators: dict[int, np.ndarray[Any, Any]] = {}
-    dtype = np.result_type(lhs.values.dtype, rhs.values.dtype)
-    zero = np.zeros(batch_shape, dtype=dtype)
 
-    for lhs_index, lhs_blade in enumerate(lhs.layout.blades):
-        lhs_component = lhs_values[..., lhs_index]
-        for rhs_index, rhs_blade in enumerate(rhs.layout.blades):
-            coefficient, out_blade = lhs.algebra.blade_product(lhs_blade, rhs_blade)
-            if coefficient == 0:
-                continue
-            support.add(out_blade)
-            contribution = coefficient * lhs_component * rhs_values[..., rhs_index]
-            if out_blade in accumulators:
-                accumulators[out_blade] = accumulators[out_blade] + contribution
-            else:
-                accumulators[out_blade] = zero + contribution
+def geometric_product(lhs: MVArray, rhs: MVArray) -> MVArray:
+    return _execute_binary_product(lhs, rhs, "geometric")
 
-    blades = tuple(sorted(support))
-    if len(blades) == lhs.algebra.blade_count:
-        layout = MVLayout.dense(lhs.algebra)
+
+def outer_product(lhs: MVArray, rhs: MVArray) -> MVArray:
+    return _execute_binary_product(lhs, rhs, "outer")
+
+
+def inner_product(lhs: MVArray, rhs: MVArray) -> MVArray:
+    return _execute_binary_product(lhs, rhs, "inner")
+
+
+def project_grades(mv: MVArray, *grades: int) -> MVArray:
+    normalized = grades[0] if len(grades) == 1 and isinstance(grades[0], tuple) else grades
+    if not normalized:
+        raise ValueError("At least one grade must be selected.")
+
+    grade_set = set(normalized)
+    for grade in grade_set:
+        if grade < 0 or grade > mv.algebra.dimension:
+            raise ValueError(f"Grade must be between 0 and {mv.algebra.dimension}.")
+
+    blades = tuple(blade for blade in mv.layout.blades if grade_of_blade(blade) in grade_set)
+    if blades == tuple(range(mv.algebra.blade_count)):
+        layout = MVLayout.dense(mv.algebra)
     else:
-        layout = MVLayout.sparse_pattern(lhs.algebra, blades, name="gp")
-
-    result = np.zeros(batch_shape + (layout.size,), dtype=dtype)
-    for out_index, blade in enumerate(layout.blades):
-        result[..., out_index] = accumulators[blade]
-    return MVArray(algebra=lhs.algebra, layout=layout, values=result)
+        name = "grade[" + ",".join(str(grade) for grade in sorted(grade_set)) + "]"
+        layout = MVLayout.sparse_pattern(mv.algebra, blades, name=name)
+    return mv.to_layout(layout)

--- a/src/amsa/plans.py
+++ b/src/amsa/plans.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cache
+from typing import Literal
+
+from amsa.layouts import MVLayout
+from amsa.specs import AlgebraSpec, grade_of_blade
+
+
+OpKind = Literal["geometric", "outer", "inner"]
+
+_LAYOUT_NAMES: dict[OpKind, str] = {
+    "geometric": "gp",
+    "outer": "op",
+    "inner": "ip",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ProductTerm:
+    lhs_index: int
+    rhs_index: int
+    out_blade: int
+    coefficient: int
+
+
+@dataclass(frozen=True, slots=True)
+class OpPlan:
+    kind: OpKind
+    algebra: AlgebraSpec
+    lhs_blades: tuple[int, ...]
+    rhs_blades: tuple[int, ...]
+    output_blades: tuple[int, ...]
+    terms: tuple[ProductTerm, ...]
+
+    def output_layout(self) -> MVLayout:
+        if len(self.output_blades) == self.algebra.blade_count:
+            return MVLayout.dense(self.algebra)
+        return MVLayout.sparse_pattern(
+            self.algebra,
+            self.output_blades,
+            name=_LAYOUT_NAMES[self.kind],
+        )
+
+
+def _include_term(kind: OpKind, lhs_blade: int, rhs_blade: int, out_blade: int) -> bool:
+    if kind == "geometric":
+        return True
+
+    lhs_grade = grade_of_blade(lhs_blade)
+    rhs_grade = grade_of_blade(rhs_blade)
+    out_grade = grade_of_blade(out_blade)
+
+    if kind == "outer":
+        return out_grade == lhs_grade + rhs_grade
+    if kind == "inner":
+        return out_grade == abs(lhs_grade - rhs_grade)
+    raise ValueError(f"Unsupported operator kind: {kind}")
+
+
+@cache
+def build_op_plan(
+    algebra: AlgebraSpec,
+    lhs_blades: tuple[int, ...],
+    rhs_blades: tuple[int, ...],
+    kind: OpKind,
+) -> OpPlan:
+    support: set[int] = set()
+    terms: list[ProductTerm] = []
+
+    for lhs_index, lhs_blade in enumerate(lhs_blades):
+        for rhs_index, rhs_blade in enumerate(rhs_blades):
+            coefficient, out_blade = algebra.blade_product(lhs_blade, rhs_blade)
+            if coefficient == 0:
+                continue
+            if not _include_term(kind, lhs_blade, rhs_blade, out_blade):
+                continue
+            support.add(out_blade)
+            terms.append(
+                ProductTerm(
+                    lhs_index=lhs_index,
+                    rhs_index=rhs_index,
+                    out_blade=out_blade,
+                    coefficient=coefficient,
+                )
+            )
+
+    return OpPlan(
+        kind=kind,
+        algebra=algebra,
+        lhs_blades=lhs_blades,
+        rhs_blades=rhs_blades,
+        output_blades=tuple(sorted(support)),
+        terms=tuple(terms),
+    )
+
+
+def plan_binary_product(lhs: MVLayout, rhs: MVLayout, kind: OpKind) -> OpPlan:
+    if lhs.algebra != rhs.algebra:
+        raise ValueError("Layouts belong to different algebras.")
+    return build_op_plan(lhs.algebra, lhs.blades, rhs.blades, kind)

--- a/src/amsa/reference.py
+++ b/src/amsa/reference.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from amsa.mv import MVArray
+from amsa.plans import OpPlan
+
+
+def execute_binary_plan(lhs: MVArray, rhs: MVArray, plan: OpPlan) -> MVArray:
+    batch_shape = np.broadcast_shapes(lhs.batch_shape, rhs.batch_shape)
+    lhs_values = np.broadcast_to(lhs.values, batch_shape + (lhs.layout.size,))
+    rhs_values = np.broadcast_to(rhs.values, batch_shape + (rhs.layout.size,))
+
+    layout = plan.output_layout()
+    dtype = np.result_type(lhs.values.dtype, rhs.values.dtype)
+    result = np.zeros(batch_shape + (layout.size,), dtype=dtype)
+    out_index = {blade: index for index, blade in enumerate(layout.blades)}
+
+    for term in plan.terms:
+        result[..., out_index[term.out_blade]] += (
+            term.coefficient * lhs_values[..., term.lhs_index] * rhs_values[..., term.rhs_index]
+        )
+
+    return MVArray(algebra=lhs.algebra, layout=layout, values=result)

--- a/src/amsa/specs.py
+++ b/src/amsa/specs.py
@@ -153,6 +153,14 @@ def vga(dimension: int) -> AlgebraSpec:
     return AlgebraSpec.from_pqr(dimension, 0, 0)
 
 
+def vga2d() -> AlgebraSpec:
+    return vga(2)
+
+
+def vga3d() -> AlgebraSpec:
+    return vga(3)
+
+
 def pga2d() -> AlgebraSpec:
     return AlgebraSpec(signature=(0, 1, 1), start_index=0)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for shared helpers and module-relative imports."""

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from amsa import Algebra, MVArray, MVLayout, pga2d, vga
-from tests._utils import assert_allclose
+
+from ._utils import assert_allclose
 
 
 def test_dense_layout_covers_full_basis() -> None:
@@ -88,11 +89,44 @@ def test_addition_unions_sparse_support() -> None:
     assert z.component("e2") == 2.0
 
 
+def test_addition_and_subtraction_support_scalars() -> None:
+    algebra = Algebra(vga(2))
+    x = algebra.multivector({"e1": 1.0})
+
+    z = x + 2.0
+    assert z.component("e") == 2.0
+    assert z.component("e1") == 1.0
+
+    z = 3.0 + x
+    assert z.component("e") == 3.0
+    assert z.component("e1") == 1.0
+
+    z = x - 2.0
+    assert z.component("e") == -2.0
+    assert z.component("e1") == 1.0
+
+    z = 2.0 - x
+    assert z.component("e") == 2.0
+    assert z.component("e1") == -1.0
+
+
 def test_batch_mapping_values_are_broadcast() -> None:
     algebra = Algebra(vga(2))
     mv = algebra.multivector({"e1": np.array([1.0, 2.0]), "e2": 3.0})
     assert mv.batch_shape == (2,)
     assert_allclose(mv.component("e2"), np.array([3.0, 3.0]))
+
+
+def test_algebra_add_and_sub_helpers_delegate_to_operator_layer() -> None:
+    algebra = Algebra(vga(2))
+    lhs = algebra.multivector({"e1": 1.0})
+    rhs = algebra.multivector({"e2": 2.0})
+    added = algebra.add(lhs, rhs)
+    subtracted = algebra.sub(lhs, rhs)
+    assert added.component("e1") == 1.0
+    assert added.component("e2") == 2.0
+    assert subtracted.component("e1") == 1.0
+    assert subtracted.component("e2") == -2.0
 
 
 def test_reverse_and_involute_sign_rules() -> None:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+
+from amsa import Algebra, MVLayout, geometric_product, inner_product, outer_product, pga2d, vga2d, vga3d
+from amsa.plans import plan_binary_product
+from amsa.specs import grade_of_blade
+from ._utils import assert_mv_allclose
+
+
+def _keep_term(kind: str, lhs_blade: int, rhs_blade: int, out_blade: int) -> bool:
+    if kind == "geometric":
+        return True
+    if kind == "outer":
+        return grade_of_blade(out_blade) == grade_of_blade(lhs_blade) + grade_of_blade(rhs_blade)
+    if kind == "inner":
+        return grade_of_blade(out_blade) == abs(grade_of_blade(lhs_blade) - grade_of_blade(rhs_blade))
+    raise ValueError(f"Unsupported operator kind: {kind}")
+
+
+def _naive_binary_product(lhs, rhs, *, kind: str):
+    batch_shape = np.broadcast_shapes(lhs.batch_shape, rhs.batch_shape)
+    lhs_values = np.broadcast_to(lhs.values, batch_shape + (lhs.layout.size,))
+    rhs_values = np.broadcast_to(rhs.values, batch_shape + (rhs.layout.size,))
+
+    support: set[int] = set()
+    accumulators: dict[int, np.ndarray] = {}
+    dtype = np.result_type(lhs.dtype, rhs.dtype)
+    zero = np.zeros(batch_shape, dtype=dtype)
+
+    for lhs_index, lhs_blade in enumerate(lhs.layout.blades):
+        lhs_component = lhs_values[..., lhs_index]
+        for rhs_index, rhs_blade in enumerate(rhs.layout.blades):
+            coefficient, out_blade = lhs.algebra.blade_product(lhs_blade, rhs_blade)
+            if coefficient == 0:
+                continue
+            if not _keep_term(kind, lhs_blade, rhs_blade, out_blade):
+                continue
+
+            support.add(out_blade)
+            contribution = coefficient * lhs_component * rhs_values[..., rhs_index]
+            if out_blade in accumulators:
+                accumulators[out_blade] = accumulators[out_blade] + contribution
+            else:
+                accumulators[out_blade] = zero + contribution
+
+    blades = tuple(sorted(support))
+    layout = MVLayout.dense(lhs.algebra) if len(blades) == lhs.algebra.blade_count else MVLayout.sparse_pattern(lhs.algebra, blades, name=kind)
+    result = np.zeros(batch_shape + (layout.size,), dtype=dtype)
+    for index, blade in enumerate(layout.blades):
+        result[..., index] = accumulators[blade]
+    return type(lhs)(algebra=lhs.algebra, layout=layout, values=result)
+
+
+@pytest.mark.parametrize(
+    ("factory", "kind", "operation"),
+    [
+        (vga2d, "geometric", geometric_product),
+        (vga2d, "outer", outer_product),
+        (vga2d, "inner", inner_product),
+        (vga3d, "geometric", geometric_product),
+        (vga3d, "outer", outer_product),
+        (vga3d, "inner", inner_product),
+        (pga2d, "geometric", geometric_product),
+        (pga2d, "outer", outer_product),
+        (pga2d, "inner", inner_product),
+    ],
+)
+def test_planned_products_match_naive_reference(factory, kind, operation) -> None:
+    algebra = Algebra(factory())
+    lhs = algebra.multivector({1: np.array([1.0, -2.0]), 2: 3.0, 3: -1.5})
+    rhs = algebra.multivector({0: 2.0, 1: np.array([0.5, 1.5]), 3: 4.0})
+
+    actual = operation(lhs, rhs)
+    expected = _naive_binary_product(lhs, rhs, kind=kind)
+    assert_mv_allclose(actual, expected)
+
+
+def test_product_plans_are_cached_by_operator_and_layout_support() -> None:
+    spec = vga3d()
+    lhs = MVLayout.grade(spec, 1, 2)
+    rhs = MVLayout.sparse_pattern(spec, (0, 1, 3, 7), name="rhs")
+
+    first = plan_binary_product(lhs, rhs, "geometric")
+    second = plan_binary_product(lhs, rhs, "geometric")
+
+    assert first is second
+    assert first.kind == "geometric"
+    assert first.lhs_blades == lhs.blades
+    assert first.rhs_blades == rhs.blades
+
+
+def test_outer_and_inner_split_vector_product_in_vga2d() -> None:
+    algebra = Algebra.vga2d()
+    u = algebra.vector([1.0, 2.0])
+    v = algebra.vector([3.0, -4.0])
+
+    assert_mv_allclose(u * v, (u | v) + (u ^ v))
+    assert (u | v).component("e") == -5.0
+    assert (u ^ v).component("e12") == -10.0
+
+
+def test_outer_and_inner_handle_basis_cases_in_vga3d() -> None:
+    algebra = Algebra.vga3d()
+    e2 = algebra.blade("e2")
+    e3 = algebra.blade("e3")
+    e12 = algebra.blade("e12")
+    e23 = algebra.blade("e23")
+
+    assert (e12 | e2).component("e1") == 1.0
+    assert (e12 ^ e3).component("e123") == 1.0
+    assert (e12 ^ e23).layout.size == 0
+
+
+def test_outer_and_inner_handle_degenerate_pga2d_cases() -> None:
+    algebra = Algebra.pga2d()
+    e0 = algebra.blade("e0")
+    e1 = algebra.blade("e1")
+
+    assert (e0 | e0).layout.size == 0
+    assert (e0 ^ e0).layout.size == 0
+    assert (e0 ^ e1).component("e01") == 1.0
+
+
+def test_named_presets_and_grade_helpers_cover_common_robotics_shapes() -> None:
+    pga = Algebra.from_name("2DPGA")
+    assert pga.signature == (0, 1, 1)
+
+    algebra = Algebra.vga3d()
+    rotor = algebra.even([1.0, 0.0, 0.5, -0.25])
+    trivector = algebra.trivector([2.0])
+    mixed = algebra.multivector({"e1": 1.0, "e12": 2.0, "e123": 3.0})
+    projected = mixed.grade(1, 3)
+
+    assert rotor.grades == (0, 2)
+    assert rotor.layout.size == 4
+    assert trivector.component("e123") == 2.0
+    assert projected.layout.blades == (1, 7)


### PR DESCRIPTION
### Prerelease : Core Architecture

This PR establishes the reference path and core mathematical structures for AMSA. It provides a structured foundation for further building.

#### Core Components
- AlgebraSpec: Defines the algebraic space properties.
- MVLayout and MVArray: Handles memory layout and multivector data.
- reference.py:  Split between the reference implementation and backend. (convenience util for now )

#### Verification Results
- Status: Passed
- Command: `uv run pytest`
- Result: 36 tests passed.

#### Available Operations
- [x] Basic: Addition, Subtraction, Scalar Multiplication.
- [x] Products: Geometric (`*`), Outer (`^`), Inner (`|`).
- [x] Unary: Negation, Reversal, Involution, Conjugation.
- [x] Management: Grade projection, as_dense(), to_layout().
- [x] Presets: VGA (2D/3D), PGA (2D/3D), and standard k-vector constructors.

#### Documentation
- Created documentation/prerelease.md covering architecture and API surface.
- Initialized examples/ directory (unpopulated).

Closes #3