### PR TITLE
add device-to-backend mapping and corresponding user API. ref #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ uv pip install amsa-ga[viz]==0.1.0b0
 - `src/amsa/mv.py`: storage-backed multivector array type
 - `src/amsa/plans.py`: cached operator plans
 - `src/amsa/reference.py`: reference execution of plans
+- `src/amsa/ir.py`: IR definitions and backend registry
+- `src/amsa/backends/`: execution backend implementations
 - `src/amsa/ops.py`: public operator layer
 - `src/amsa/algebra.py`: user-facing algebra handle and constructors
 - `src/amsa/viz/`: visualization adapters, neutral primitives, and optional backends
@@ -89,6 +91,25 @@ s = alg.scalar(1.0)
 
 Use `alg.scalar(1.0)`, not `alg.multivector(1.0)`.
 
+## Execution Backends
+
+AMSA supports pluggable execution backends for coefficient computation. Backends are selected by device type:
+
+```python
+import amsa
+
+# CPU execution (NumPy) - default
+amsa.init(use="cpu")
+
+# GPU execution (JAX) - requires amsa-ga[jax] extra
+# amsa.init(use="gpu")
+
+# Check current device
+print(amsa.get_device())  # "cpu"
+```
+
+See the documentation for details on execution backends.
+
 ## Documentation
 
 Full documentation is in `docs/` 
@@ -103,6 +124,7 @@ You can also browse the source directly:
 - `docs/algebra.rst` — `AlgebraSpec`, presets, and blade products
 - `docs/layouts.rst` — `MVLayout` and sparse support
 - `docs/storage.rst` — dense and CSR backends
+- `docs/backends.rst` — execution backend selection (CPU/GPU)
 - `docs/operators.rst` — product semantics, duality, and normalization
 - `docs/viz.rst` — visualization adapters, primitives, and optional matplotlib/VisPy backends
 - `docs/examples.rst` — index of runnable example scripts

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -1,0 +1,60 @@
+Execution backends
+==================
+
+AMSA supports pluggable execution backends for coefficient computation.
+Backends are selected by device type rather than library name, making the API
+more intuitive for users who think in terms of CPU/GPU execution.
+
+Device selection
+---------------
+
+Use ``amsa.init()`` to select the execution device:
+
+.. code-block:: python
+
+   import amsa
+   
+   # CPU execution (NumPy) - default
+   amsa.init(use="cpu")
+   
+   # GPU execution (JAX) - requires JAX backend
+   # amsa.init(use="gpu")
+   
+   # Check current device
+   print(amsa.get_device())  # "cpu"
+
+Backend mapping
+---------------
+
+AMSA maps device types to specific backend implementations:
+
+- ``cpu`` → NumPy backend (always available)
+- ``gpu`` → JAX backend (requires ``amsa-ga[jax]`` extra)
+
+The NumPy backend is registered and set as the default on import, so most
+users do not need to call ``amsa.init()`` unless they want to explicitly
+switch devices.
+
+Important notes
+---------------
+
+- Backend selection affects **coefficient execution only**
+- Algebra semantics, blade identity, and layout ordering are unchanged
+- Storage backend (dense/CSR) is independent of execution backend
+- Device selection is global for the current Python process
+
+Future backends
+--------------
+
+Additional backends can be registered via the low-level ``amsa.ir`` module:
+
+.. code-block:: python
+
+   from amsa.ir import register_backend
+   
+   # Register a custom backend
+   register_backend("my_backend", MyExecutor())
+   amsa.init(use="cpu")  # Switches to registered backend
+
+See the ``amsa.ir`` module documentation for the ``Executor`` protocol and
+backend registration details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ It is built on a matrix-free core: blades are bit-pattern identifiers, layouts d
    algebra
    layouts
    storage
+   backends
    operators
    viz
    examples

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -91,6 +91,22 @@ By default, fresh construction uses dense storage. You can opt into CSR explicit
 
    print(mv.storage_kind)  # csr
 
+Execution backends
+------------------
+
+AMSA uses CPU (NumPy) execution by default. You can select the device:
+
+.. code-block:: python
+
+   import amsa
+   
+   amsa.init(use="cpu")  # NumPy backend (default)
+   # amsa.init(use="gpu")  # JAX backend (requires amsa-ga[jax])
+   
+   print(amsa.get_device())  # "cpu"
+
+See :doc:`backends` for more details on execution backends.
+
 Visualization
 -------------
 

--- a/src/amsa/__init__.py
+++ b/src/amsa/__init__.py
@@ -16,7 +16,7 @@ from amsa.algebra import Algebra
 
 # Register the NumPy IR backend as the default execution engine.
 from amsa.backends.numpy import NumpyBackend
-from amsa.ir import register_backend
+from amsa.ir import get_device, init, register_backend
 from amsa.layouts import MVLayout
 from amsa.mv import MVArray
 from amsa.ops import (
@@ -64,12 +64,15 @@ from amsa.ops import (
 from amsa.specs import AlgebraSpec, grade_of_blade, pga2d, pga3d, vga, vga2d, vga3d
 
 register_backend("numpy", NumpyBackend())
+init(use="cpu")
 
 __all__ = [
     "Algebra",
     "AlgebraSpec",
     "MVArray",
     "MVLayout",
+    "get_device",
+    "init",
     "add",
     "anticommutator_product",
     "bulk",

--- a/src/amsa/ir.py
+++ b/src/amsa/ir.py
@@ -577,3 +577,41 @@ def clear_backends() -> None:
     global _DEFAULT_BACKEND
     _BACKENDS.clear()
     _DEFAULT_BACKEND = None
+
+
+_DEVICE_BACKENDS: dict[str, str] = {
+    "cpu": "numpy",
+    "gpu": "jax",
+}
+
+
+def init(use: str = "cpu") -> None:
+    """Initialize AMSA with a specific device backend.
+
+    Args:
+        use: Device type - "cpu" (NumPy) or "gpu" (JAX, when available).
+
+    Raises:
+        ValueError: If device is not supported or backend not registered.
+    """
+    if use not in _DEVICE_BACKENDS:
+        raise ValueError(
+            f"Unsupported device: {use!r}. Supported: {list(_DEVICE_BACKENDS)}"
+        )
+    backend_name = _DEVICE_BACKENDS[use]
+    if not has_backend(backend_name):
+        raise ValueError(
+            f"Backend {backend_name!r} for device {use!r} is not available. "
+            f"Available backends: {list_backends()}."
+        )
+    set_default_backend(backend_name)
+
+
+def get_device() -> str:
+    """Return the current device in use."""
+    backend = get_backend()
+    backend_name = type(backend).__name__.lower()
+    for device, name in _DEVICE_BACKENDS.items():
+        if backend_name.startswith(name):
+            return device
+    return "cpu"

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Surya Sunkara
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import amsa
+from amsa.backends.numpy import NumpyBackend
+from amsa.ir import clear_backends, get_device, init, register_backend
+
+
+def test_init_cpu():
+    """Test initializing with CPU device."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    init(use="cpu")
+    assert get_device() == "cpu"
+
+
+def test_init_invalid_device():
+    """Test that invalid device raises ValueError."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    with pytest.raises(ValueError, match="Unsupported device"):
+        init(use="tpu")
+
+
+def test_init_unregistered_backend():
+    """Test that device with unregistered backend raises ValueError."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    with pytest.raises(ValueError, match="Backend.*not available"):
+        init(use="gpu")
+
+
+def test_get_device():
+    """Test getting current device."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    init(use="cpu")
+    assert get_device() == "cpu"
+
+
+def test_operations_use_selected_backend():
+    """Test that operations work after backend selection."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    init(use="cpu")
+    
+    alg = amsa.Algebra.vga2d()
+    u = alg.vector([1.0, 2.0])
+    v = alg.vector([3.0, -4.0])
+    
+    result = u * v
+    assert result is not None
+    # Geometric product of two vectors in VGA2D returns scalar + bivector (2 components)
+    assert result.values.shape == (2,)
+
+
+def test_algebra_semantics_unchanged():
+    """Test that backend selection does not affect algebra semantics."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    init(use="cpu")
+    
+    alg = amsa.Algebra.vga2d()
+    u = alg.vector([1.0, 0.0])
+    v = alg.vector([0.0, 1.0])
+    
+    # Outer product of orthogonal vectors should be bivector
+    op = u ^ v
+    assert op.layout.blades == (3,)  # e12 in VGA2D
+    
+    # Inner product should be scalar
+    ip = u | v
+    assert ip.layout.blades == (0,)  # scalar
+
+
+def test_backend_persistence():
+    """Test that backend selection persists across operations."""
+    clear_backends()
+    register_backend("numpy", NumpyBackend())
+    init(use="cpu")
+    
+    assert get_device() == "cpu"
+    
+    # Perform multiple operations
+    alg = amsa.Algebra.vga2d()
+    for _ in range(3):
+        u = alg.vector([1.0, 2.0])
+        v = alg.vector([3.0, -4.0])
+        _ = u * v
+    
+    # Device should still be cpu
+    assert get_device() == "cpu"
+
+
+def test_public_api_exports():
+    """Test that init and get_device are exported in public API."""
+    assert hasattr(amsa, "init")
+    assert hasattr(amsa, "get_device")
+    assert callable(amsa.init)
+    assert callable(amsa.get_device)


### PR DESCRIPTION
# PR Description

This PR implements a user-facing backend selection API that allows users to switch execution devices (CPU/GPU).

## Changes

### Core Implementation
- `src/amsa/ir.py`: Added device-to-backend mapping (`_DEVICE_BACKENDS`), `init(use="cpu")` function for device selection, and `get_device()`function to check current device
- `src/amsa/__init__.py`: Exposed `init` and `get_device` in public API, set `CPU (NumPy)` as default on import

### Documentation
- `docs/backends.rst` New documentation page covering execution backend selection, device mapping, and important notes about what backend selection affects
- `docs/index.rst`: Added backends to table of contents
- `docs/quickstart.rst:` Added "Execution backends" section with usage examples
- `README.md`: Added "Execution Backends" section with examples, updated package layout to include

### Tests
Added 8 new tests covering device initialization, error handling, operations, algebra semantics, backend persistence, and public API exports

## API Usage

```python
import amsa

# CPU execution (NumPy) - default
amsa.init(use="cpu")

# GPU execution (JAX) - requires amsa-ga[jax] extra
# amsa.init(use="gpu")

# Check current device
print(amsa.get_device())  # "cpu"
```

## Verification

- All 8 new tests pass
- Existing tests continue to pass (218 total)
- Code style compliant (ruff, mypy)
